### PR TITLE
Fix some errors on code

### DIFF
--- a/Part 2 - Neural Networks in PyTorch.ipynb
+++ b/Part 2 - Neural Networks in PyTorch.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "# Define a transform to normalize the data\n",
     "transform = transforms.Compose([transforms.ToTensor(),\n",
-    "                              transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),\n",
+    "                              transforms.Normalize((0.5,), (0.5,)),\n",
     "                             ])\n",
     "# Download and load the training data\n",
     "trainset = datasets.MNIST('MNIST_data/', download=True, train=True, transform=transform)\n",

--- a/Part 3 - Training Neural Networks.ipynb
+++ b/Part 3 - Training Neural Networks.ipynb
@@ -218,7 +218,7 @@
     "\n",
     "# Define a transform to normalize the data\n",
     "transform = transforms.Compose([transforms.ToTensor(),\n",
-    "                              transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),\n",
+    "                              transforms.Normalize((0.5,), (0.5,)),\n",
     "                             ])\n",
     "# Download and load the training data\n",
     "trainset = datasets.MNIST('MNIST_data/', download=True, train=True, transform=transform)\n",

--- a/Part 4 - Fashion-MNIST Exercise.ipynb
+++ b/Part 4 - Fashion-MNIST Exercise.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "# Define a transform to normalize the data\n",
     "transform = transforms.Compose([transforms.ToTensor(),\n",
-    "                                transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])\n",
+    "                                transforms.Normalize((0.5,), (0.5,))])\n",
     "# Download and load the training data\n",
     "trainset = datasets.FashionMNIST('F_MNIST_data/', download=True, train=True, transform=transform)\n",
     "trainloader = torch.utils.data.DataLoader(trainset, batch_size=64, shuffle=True)\n",

--- a/Part 5 - Inference and Validation.ipynb
+++ b/Part 5 - Inference and Validation.ipynb
@@ -43,7 +43,7 @@
    "source": [
     "# Define a transform to normalize the data\n",
     "transform = transforms.Compose([transforms.ToTensor(),\n",
-    "                                transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])\n",
+    "                                transforms.Normalize((0.5,), (0.5,))])\n",
     "# Download and load the training data\n",
     "trainset = datasets.FashionMNIST('F_MNIST_data/', download=True, train=True, transform=transform)\n",
     "trainloader = torch.utils.data.DataLoader(trainset, batch_size=64, shuffle=True)\n",

--- a/Part 6 - Saving and Loading Models.ipynb
+++ b/Part 6 - Saving and Loading Models.ipynb
@@ -38,7 +38,7 @@
    "source": [
     "# Define a transform to normalize the data\n",
     "transform = transforms.Compose([transforms.ToTensor(),\n",
-    "                                transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])\n",
+    "                                transforms.Normalize((0.5,), (0.5,))])\n",
     "# Download and load the training data\n",
     "trainset = datasets.FashionMNIST('F_MNIST_data/', download=True, train=True, transform=transform)\n",
     "trainloader = torch.utils.data.DataLoader(trainset, batch_size=64, shuffle=True)\n",

--- a/Part 7 - Loading Image Data.ipynb
+++ b/Part 7 - Loading Image Data.ipynb
@@ -239,7 +239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/Part 7 - Loading Image Data.ipynb
+++ b/Part 7 - Loading Image Data.ipynb
@@ -120,7 +120,7 @@
    "source": [
     "If you loaded the data correctly, you should see something like this (your image will be different):\n",
     "\n",
-    "<img src='assets/cat_cropped.png', width=244>"
+    "<img src='assets/cat_cropped.png' width=244>"
    ]
   },
   {
@@ -239,7 +239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The parameters of transforms.Normalize are for color images. However, the NMIST data are consists of gray-scale images. Therefore, the parameters should be changed for the one color channel. 

Also, there is a minor bug in the inline HTML that blocks to display an image in the asset directory.